### PR TITLE
Make double array parameters non-required

### DIFF
--- a/src/main/java/ch/fmi/ApplyAffineTransformPoints.java
+++ b/src/main/java/ch/fmi/ApplyAffineTransformPoints.java
@@ -13,16 +13,16 @@ import org.scijava.plugin.Plugin;
 
 @Plugin(type = Command.class, headless = true, menuPath = "FMI>Apply 3D Affine Transform to Points")
 public class ApplyAffineTransformPoints implements Command {
-	@Parameter(label = "x Coordinates")
+	@Parameter(label = "x Coordinates", required = false)
 	private double[] xIn;
 
-	@Parameter(label = "y Coordinates")
+	@Parameter(label = "y Coordinates", required = false)
 	private double[] yIn;
 
-	@Parameter(label = "z Coordinates")
+	@Parameter(label = "z Coordinates", required = false)
 	private double[] zIn;
 
-	@Parameter(label = "Affine transformation matrix")
+	@Parameter(label = "Affine transformation matrix", required = false)
 	private double[] m;
 
 	@Parameter(label = "Apply inverse", required = false, persist = false)

--- a/src/main/java/ch/fmi/PointCloudSeriesRegistration.java
+++ b/src/main/java/ch/fmi/PointCloudSeriesRegistration.java
@@ -60,20 +60,20 @@ public class PointCloudSeriesRegistration <M extends AbstractModel<M>> extends C
 	@Parameter(label = "Dimensionality", choices = { DIM2D, DIM3D })
 	private String dim;
 
-	@Parameter(label = "Frame Numbers")
+	@Parameter(label = "Frame Numbers", required = false)
 	private double[] frame;
 
-	@Parameter(label = "X Coordinates")
+	@Parameter(label = "X Coordinates", required = false)
 	private double[] xCoords;
 
-	@Parameter(label = "Y Coordinates")
+	@Parameter(label = "Y Coordinates", required = false)
 	private double[] yCoords;
 
 	@Parameter(label = "Z Coordinates", required = false)
 	private double[] zCoords = null;
 
-	@Parameter(label = "Range")
-	private int range = 10;
+	@Parameter(label = "Range", required = false)
+	private Integer range = 10;
 
 	// --- OUTPUTS ---
 


### PR DESCRIPTION
This allows the ImageJ dialog panel to be populated without `SwingInputHarvester` throwing an exception.

See https://github.com/knime-ip/knip-imagej2/issues/17#issuecomment-727224281.