### PR TITLE
Add point-cloud registration for prematched points

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>29.2.1</version>
+		<version>30.0.0</version>
 		<relativePath />
 	</parent>
 

--- a/src/main/java/ch/fmi/registration/Utils.java
+++ b/src/main/java/ch/fmi/registration/Utils.java
@@ -1,0 +1,213 @@
+package ch.fmi.registration;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Vector;
+
+import com.google.common.primitives.Doubles;
+
+import mpicbg.imglib.algorithm.scalespace.DifferenceOfGaussian.SpecialPoint;
+import mpicbg.imglib.algorithm.scalespace.DifferenceOfGaussianPeak;
+import mpicbg.imglib.type.numeric.real.FloatType;
+import mpicbg.models.AbstractModel;
+import mpicbg.models.Affine2D;
+import mpicbg.models.Affine3D;
+import mpicbg.models.AffineModel2D;
+import mpicbg.models.AffineModel3D;
+import mpicbg.models.IllDefinedDataPointsException;
+import mpicbg.models.InterpolatedAffineModel2D;
+import mpicbg.models.InterpolatedAffineModel3D;
+import mpicbg.models.InvertibleBoundable;
+import mpicbg.models.Model;
+import mpicbg.models.NotEnoughDataPointsException;
+import mpicbg.models.PointMatch;
+import mpicbg.models.RigidModel2D;
+import mpicbg.models.RigidModel3D;
+import mpicbg.models.SimilarityModel2D;
+import mpicbg.models.SimilarityModel3D;
+import mpicbg.models.TranslationModel2D;
+import mpicbg.models.TranslationModel3D;
+import net.imglib2.util.Pair;
+import net.imglib2.util.ValuePair;
+import process.ComparePair;
+import process.Particle;
+
+public class Utils {
+	private Utils() {
+		// prevent instantiation of static utility class
+	}
+
+	final static public String TRANSLATION = "Translation";
+	final static public String RIGID = "Rigid";
+	final static public String SIMILARITY = "Similarity";
+	final static public String AFFINE = "Affine";
+	final static public String DIM2D = "2D";
+	final static public String DIM3D = "3D";
+
+	public static Vector<ComparePair> getComparePairs(Integer[] frameLookup,
+			ArrayList<ArrayList<DifferenceOfGaussianPeak<FloatType>>> peakList, int range, Model<?> model) {
+
+		final Vector<ComparePair> pairs = new Vector<>();
+
+		int nFrames = peakList.size();
+
+		for (int a = 0; a < nFrames; a++) {
+			for (int b = a + 1; b < nFrames; b++) {
+				if (Math.abs(frameLookup[a] - frameLookup[b]) <= range)
+					pairs.add(new ComparePair(a, b, model));
+			}
+		}
+
+		return pairs;
+	}
+
+	public static void populateComparePairs(Vector<ComparePair> pairs,
+			ArrayList<ArrayList<DifferenceOfGaussianPeak<FloatType>>> peaks, List<List<Integer>> correspondences) {
+		for (ComparePair pair : pairs) {
+			ArrayList<DifferenceOfGaussianPeak<FloatType>> peaksA = peaks.get(pair.indexA);
+			ArrayList<DifferenceOfGaussianPeak<FloatType>> peaksB = peaks.get(pair.indexB);
+			List<Integer> idsA = correspondences.get(pair.indexA);
+			List<Integer> idsB = correspondences.get(pair.indexB);
+
+			int id = 0;
+			for (int a = 0; a < peaksA.size(); a++) {
+				for (int b = 0; b < peaksB.size(); b++) {
+					if (idsA.get(a).equals(idsB.get(b))) {
+						pair.inliers.add(new PointMatch(new Particle(id++, peaksA.get(a), 1.0f),
+								new Particle(id++, peaksB.get(b), 1.0f)));
+					}
+				}
+			}
+
+			try {
+				pair.model.fit(pair.inliers);
+			} catch (NotEnoughDataPointsException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			} catch (IllDefinedDataPointsException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+		}
+	}
+
+	public static Integer[] getSortedUniqueFrames(int[] frames) {
+		return Arrays.stream(frames).distinct().sorted().boxed().toArray(Integer[]::new);
+	}
+
+	public static Pair<ArrayList<ArrayList<DifferenceOfGaussianPeak<FloatType>>>, List<List<Integer>>> getPeaksAndCorrespondencesFromArrays(
+			List<Integer> sortedUniqueFrames, int[] frames, double[] x, double[] y, double[] z, int[] correspondences) {
+
+		ArrayList<ArrayList<DifferenceOfGaussianPeak<FloatType>>> peaks = new ArrayList<>(sortedUniqueFrames.size());
+		List<List<Integer>> ids = new ArrayList<>(sortedUniqueFrames.size());
+
+		for (int i = 0; i < sortedUniqueFrames.size(); i++) {
+			peaks.add(new ArrayList<>());
+			ids.add(new ArrayList<>());
+		}
+
+		for (int i = 0; i < frames.length; i++) {
+			peaks.get(sortedUniqueFrames.indexOf(frames[i])).add(Utils.createPeak(x[i], y[i], z[i]));
+			ids.get((sortedUniqueFrames.indexOf(frames[i]))).add(correspondences[i]);
+		}
+		return new ValuePair<ArrayList<ArrayList<DifferenceOfGaussianPeak<FloatType>>>, List<List<Integer>>>(peaks, ids);
+	}
+
+	public static ArrayList<ArrayList<DifferenceOfGaussianPeak<FloatType>>> getPeaksFromArrays(
+			List<Integer> sortedUniqueFrames, int[] frames, double[] x, double[] y, double[] z) {
+
+		ArrayList<ArrayList<DifferenceOfGaussianPeak<FloatType>>> peaks = new ArrayList<>(sortedUniqueFrames.size());
+
+		for (int i = 0; i < sortedUniqueFrames.size(); i++) {
+			peaks.add(new ArrayList<>());
+		}
+
+		for (int i = 0; i < frames.length; i++) {
+			peaks.get(sortedUniqueFrames.indexOf((int) frames[i])).add(Utils.createPeak(x[i], y[i], z[i]));
+		}
+		return peaks;
+	}
+
+	public static DifferenceOfGaussianPeak<FloatType> createPeak(double x, double y, double z) {
+		int[] loc = new int[] { (int) x, (int) y, (int) z };
+		DifferenceOfGaussianPeak<FloatType> p = new DifferenceOfGaussianPeak<>(loc, new FloatType(), SpecialPoint.MAX);
+		p.setSubPixelLocationOffset((float) (x - loc[0]), 0);
+		p.setSubPixelLocationOffset((float) (y - loc[1]), 1);
+		p.setSubPixelLocationOffset((float) (z - loc[2]), 2);
+		return p;
+	}
+
+	public static AbstractModel<?> suitableModel(String d, String transform) {
+		switch (transform) {
+		case TRANSLATION:
+			return d.equals(DIM2D) ? new TranslationModel2D() : new TranslationModel3D();
+		case RIGID:
+			return d.equals(DIM2D) ? new RigidModel2D() : new RigidModel3D();
+		case SIMILARITY:
+			return d.equals(DIM2D) ? new SimilarityModel2D() : new SimilarityModel3D();
+		case AFFINE:
+		default:
+			return d.equals(DIM2D) ? new AffineModel2D() : new AffineModel3D();
+		}
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	public static AbstractModel<?> suitableRegularizedModel(String d, String transform, String regularizer, double lambda) {
+		switch (d) {
+		case DIM2D:
+			return new InterpolatedAffineModel2D(suitableModel(d, transform), suitableModel(d, regularizer), lambda);
+		case DIM3D:
+		default:
+			return new InterpolatedAffineModel3D(suitableModel(d, transform), suitableModel(d, regularizer), lambda);
+		}
+	}
+
+	public static double[] flattenModels(List<InvertibleBoundable> models, String dim) {
+		List<Double> list = new ArrayList<>();
+		double[] m;
+
+		switch (dim) {
+		case DIM2D:
+			m = new double[6];
+			for (int i = 0; i < models.size(); i++) {
+				((Affine2D<?>) models.get(i)).toArray(m);
+				list.add(m[0]);
+				list.add(m[2]);
+				list.add(0d);
+				list.add(m[4]);
+				list.add(m[1]);
+				list.add(m[3]);
+				list.add(0d);
+				list.add(m[5]);
+				list.add(0d);
+				list.add(0d);
+				list.add(1d);
+				list.add(0d);
+			}
+			break;
+		case DIM3D:
+		default:
+			m = new double[12];
+			for (int i = 0; i < models.size(); i++) {
+				((Affine3D<?>) models.get(i)).toArray(m);
+				list.add(m[0]);
+				list.add(m[3]);
+				list.add(m[6]);
+				list.add(m[9]);
+				list.add(m[1]);
+				list.add(m[4]);
+				list.add(m[7]);
+				list.add(m[10]);
+				list.add(m[2]);
+				list.add(m[5]);
+				list.add(m[8]);
+				list.add(m[11]);
+			}
+			break;
+		}
+
+		return Doubles.toArray(list);
+	}
+
+}

--- a/src/test/java/ch/fmi/PointCloudSeriesRegistrationPrematchedTest.java
+++ b/src/test/java/ch/fmi/PointCloudSeriesRegistrationPrematchedTest.java
@@ -1,0 +1,143 @@
+/*-
+ * #%L
+ * A collection of plugins developed at the FMI Basel.
+ * %%
+ * Copyright (C) 2016 - 2020 FMI Basel
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
+package ch.fmi;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertThrows;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.scijava.Context;
+import org.scijava.command.CommandModule;
+import org.scijava.command.CommandService;
+
+import ch.fmi.registration.Utils;
+
+public class PointCloudSeriesRegistrationPrematchedTest {
+
+	private Context context;
+	private CommandService commandService;
+
+	@Before
+	public void initialize() {
+		context = new Context();
+		commandService = context.service(CommandService.class);
+	}
+
+	@After
+	public void disposeContext() {
+		if (context != null) {
+			context.dispose();
+			context = null;
+		}
+	}
+
+	@Test
+	public void testSeriesRegistration() throws InterruptedException, ExecutionException
+	{
+		// Create Point Arrays
+		double[] x = { //
+			0, 0, 1, 1, 1, 2, //
+			1, 2.1, 2, 0.9, 2, 3, //
+			2, 3, 2, 3, 3, 4 //
+		};
+		double[] y = { //
+			0, 1, 1, 0, 1, 2, //
+			1, 2, 0.9, 2, 2.1, 3, //
+			1, 2, 2, 1, 2, 3 //
+		};
+		double[] z = { //
+			0, 1, 0, 1, 1, 2, //
+			1, 1, 2, 2, 2, 3, //
+			0, 0, 1, 1, 1, 2 //
+		};
+		double[] frame = { //
+			0, 0, 0, 0, 0, 0,//
+			1, 1, 1, 1, 1, 1, //
+			3, 3, 3, 3, 3, 3 //
+		};
+		double[] trackIDs = { //
+				1, 42, 75, 57, 999, 7, //
+				1, 75, 57, 42, 999, 7, //
+				1, 75, 42, 57, 999, 7 //
+		};
+
+		Map<String, Object> inputMap = new HashMap<>();
+		inputMap.put("transformType", Utils.TRANSLATION);
+		inputMap.put("dim", Utils.DIM3D);
+		inputMap.put("xCoords", x);
+		inputMap.put("yCoords", y);
+		inputMap.put("zCoords", z);
+		inputMap.put("frame", frame);
+		inputMap.put("trackIDs", trackIDs);
+		inputMap.put("range", 3);
+
+		// Fit Model
+		CommandModule module = commandService.run(PointCloudSeriesRegistrationPrematched.class, true, inputMap).get();
+
+		// Compare
+		double[] expectedModels = { //
+			1, 0, 0,  0,   0, 1, 0,  0,   0, 0, 1,  0, //
+			1, 0, 0, -1,   0, 1, 0, -1,   0, 0, 1, -1, //
+			1, 0, 0, -2,   0, 1, 0, -1,   0, 0, 1,  0  //
+		};
+		double[] flatModels = (double[]) module.getOutput("flatModels");
+		System.out.println(Arrays.toString(flatModels));
+		assertArrayEquals("Models", expectedModels, flatModels, 0.01);
+
+		int[] frames = { 0, 1, 3 };
+		int[] frameList = (int[]) module.getOutput("frameList");
+		System.out.println(Arrays.toString(flatModels));
+		assertArrayEquals("Frame list", frames, frameList);
+	}
+
+	@Test
+	public void testWrongInputs() {
+		double[] x = { 0, 0 };
+		double[] y = { 0, 0, 0 };
+		double[] z = { 0, 0, 0 };
+		double[] frame = { 0, 0 };
+		double[] trackIDs = { 2, 7 };
+
+		Map<String, Object> inputMap = new HashMap<>();
+		inputMap.put("transformType", Utils.TRANSLATION);
+		inputMap.put("dim", Utils.DIM3D);
+		inputMap.put("xCoords", x);
+		inputMap.put("yCoords", y);
+		inputMap.put("zCoords", z);
+		inputMap.put("frame", frame);
+		inputMap.put("trackIDs", trackIDs);
+		inputMap.put("range", 3);
+
+		// TODO use @ExpectedException with expectCause(instanceOf(IllegalArgumentException.class))
+		assertThrows(ExecutionException.class, () -> commandService.run(
+				PointCloudSeriesRegistrationPrematched.class, true, inputMap).get());
+	}
+
+	
+}

--- a/src/test/java/ch/fmi/registration/UtilsTest.java
+++ b/src/test/java/ch/fmi/registration/UtilsTest.java
@@ -1,0 +1,248 @@
+package ch.fmi.registration;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Vector;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.junit.Test;
+
+import mpicbg.imglib.algorithm.scalespace.DifferenceOfGaussianPeak;
+import mpicbg.imglib.type.numeric.real.FloatType;
+import mpicbg.models.AbstractModel;
+import mpicbg.models.AffineModel2D;
+import mpicbg.models.AffineModel3D;
+import mpicbg.models.InterpolatedAffineModel2D;
+import mpicbg.models.InterpolatedAffineModel3D;
+import mpicbg.models.InvertibleBoundable;
+import mpicbg.models.RigidModel2D;
+import mpicbg.models.RigidModel3D;
+import mpicbg.models.TranslationModel2D;
+import mpicbg.models.TranslationModel3D;
+import net.imglib2.util.Pair;
+import process.ComparePair;
+
+public class UtilsTest {
+
+	// Create Frame Array
+	private static int[] frames = { //
+			0, 0, 0, 0, 0, 0,//
+			1, 1, 1, 1, 1, 1, //
+			3, 3, 3, 3, 3, 3 //
+		};
+
+	// Create Frame Array
+	private static int[] trackIDs = { //
+			2, 42, 13, 157, 999, 1,//
+			2, 42, 13, 157, 999, 5, //
+			2, 42, 13, 157, 999, 7 //
+		};
+
+	// Create Coordinate Arrays
+	private static double[] x = { //
+		0, 0, 1, 1, 1, 2, //
+		1, 2.1, 2, 0.9, 2, 3, //
+		2, 3, 2, 3, 3, 4 //
+	};
+	private static double[] y = { //
+		0, 1, 1, 0, 1, 2, //
+		1, 2, 0.9, 2, 2.1, 3, //
+		1, 2, 2, 1, 2, 3 //
+	};
+	private static double[] z = { //
+		0, 1, 0, 1, 1, 2, //
+		1, 1, 2, 2, 2, 3, //
+		0, 0, 0, 1, 1, 2 //
+	};
+
+	@Test
+	public void testCreatePeak() {
+		double[] loc = { 1.5, 2.4, 3.6 };
+		DifferenceOfGaussianPeak<FloatType> peak = Utils.createPeak(loc[0], loc[1], loc[2]);
+		assertEquals(loc[0], peak.getSubPixelPosition(0), 0.00001);
+		assertEquals(loc[1], peak.getSubPixelPosition(1), 0.00001);
+		assertEquals(loc[2], peak.getSubPixelPosition(2), 0.00001);
+	}
+
+	@Test
+	public void testGetSortedUniqueFrames() {
+		Integer[] expected = { 0, 1, 3 };
+		Integer[] unique = Utils.getSortedUniqueFrames(frames);
+		assertArrayEquals(expected, unique);
+	}
+
+	@Test
+	public void testGetPeaksFromArrays() {
+		List<Integer> sortedUniqueFrames = Arrays.asList(Utils.getSortedUniqueFrames(frames));
+		Map<Integer, Long> countMap = Arrays.stream(frames).boxed().collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
+
+		ArrayList<ArrayList<DifferenceOfGaussianPeak<FloatType>>> peakList = Utils.getPeaksFromArrays(sortedUniqueFrames, frames, x, y, z);
+
+		assertEquals(sortedUniqueFrames.size(), peakList.size());
+		assertEquals((long) countMap.get(sortedUniqueFrames.get(0)), peakList.get(0).size());
+		assertEquals((long) countMap.get(sortedUniqueFrames.get(1)), peakList.get(1).size());
+		assertEquals((long) countMap.get(sortedUniqueFrames.get(2)), peakList.get(2).size());
+	}
+
+	@Test
+	public void testGetPeaksAndCorrespondencesFromArrays() {
+		List<Integer> sortedUniqueFrames = Arrays.asList(Utils.getSortedUniqueFrames(frames));
+		Map<Integer, Long> countMap = Arrays.stream(frames).boxed().collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
+
+		Pair<ArrayList<ArrayList<DifferenceOfGaussianPeak<FloatType>>>, List<List<Integer>>> values = Utils
+				.getPeaksAndCorrespondencesFromArrays(sortedUniqueFrames, frames, x, y, z, trackIDs);
+
+		ArrayList<ArrayList<DifferenceOfGaussianPeak<FloatType>>> peakList = values.getA();
+		List<List<Integer>> correspondences = values.getB();
+
+		assertEquals(sortedUniqueFrames.size(), peakList.size());
+		assertEquals(sortedUniqueFrames.size(), correspondences.size());
+
+		assertEquals((long) countMap.get(sortedUniqueFrames.get(0)), correspondences.get(0).size());
+		assertEquals((long) countMap.get(sortedUniqueFrames.get(1)), correspondences.get(1).size());
+		assertEquals((long) countMap.get(sortedUniqueFrames.get(2)), correspondences.get(2).size());
+
+		Integer[] expected = { 2, 42, 13, 157, 999, 1 };
+		assertArrayEquals(expected, correspondences.get(0).toArray());
+	}
+
+	@Test
+	public void testGetComparePairs() {
+		Integer[] frameLookup = Utils.getSortedUniqueFrames(frames);
+		ArrayList<ArrayList<DifferenceOfGaussianPeak<FloatType>>> peaks = Utils
+				.getPeaksFromArrays(Arrays.asList(frameLookup), frames, x, y, z);
+		int range = 3;
+
+		Vector<ComparePair> pairs = Utils.getComparePairs(frameLookup, peaks, range, new AffineModel3D());
+
+		assertEquals(3, pairs.size());
+
+		assertEquals(0, pairs.get(0).indexA);
+		assertEquals(1, pairs.get(0).indexB);
+
+		assertEquals(0, pairs.get(1).indexA);
+		assertEquals(2, pairs.get(1).indexB);
+
+		assertEquals(1, pairs.get(2).indexA);
+		assertEquals(2, pairs.get(2).indexB);
+	}
+
+	@Test
+	public void testPopulateComparePairs() {
+		Integer[] frameLookup = Utils.getSortedUniqueFrames(frames);
+		Pair<ArrayList<ArrayList<DifferenceOfGaussianPeak<FloatType>>>, List<List<Integer>>> values = Utils
+				.getPeaksAndCorrespondencesFromArrays(Arrays.asList(frameLookup), frames, x, y, z, trackIDs);
+		ArrayList<ArrayList<DifferenceOfGaussianPeak<FloatType>>> peakList = values.getA();
+		List<List<Integer>> correspondences = values.getB();
+
+		int range = 1;
+
+		Vector<ComparePair> pairs = Utils.getComparePairs(frameLookup, peakList, range, new TranslationModel3D());
+		Utils.populateComparePairs(pairs, peakList, correspondences);
+
+		assertEquals(1, pairs.size());
+		assertEquals(5, pairs.get(0).inliers.size());
+	}
+
+	@Test
+	public void testSuitableModel() {
+		assertTrue(Utils.suitableModel(Utils.DIM3D, Utils.AFFINE) instanceof AffineModel3D);
+		assertTrue(Utils.suitableModel(Utils.DIM3D, Utils.RIGID) instanceof RigidModel3D);
+		assertTrue(Utils.suitableModel(Utils.DIM2D, Utils.AFFINE) instanceof AffineModel2D);
+		assertTrue(Utils.suitableModel(Utils.DIM2D, Utils.RIGID) instanceof RigidModel2D);
+	}
+
+	@SuppressWarnings("rawtypes")
+	@Test
+	public void testSuitableRegularizedModel() {
+		AbstractModel<?> model1 = Utils.suitableRegularizedModel(Utils.DIM2D, Utils.AFFINE, Utils.TRANSLATION, 0.1);
+		assertTrue(model1 instanceof InterpolatedAffineModel2D);
+		assertTrue(((InterpolatedAffineModel2D) model1).getA() instanceof AffineModel2D);
+		assertTrue(((InterpolatedAffineModel2D) model1).getB() instanceof TranslationModel2D);
+		assertEquals(0.1, ((InterpolatedAffineModel2D) model1).getLambda(), 0.0);
+
+		AbstractModel<?> model2 = Utils.suitableRegularizedModel(Utils.DIM3D, Utils.AFFINE, Utils.RIGID, 0.3);
+		assertTrue(model2 instanceof InterpolatedAffineModel3D);
+		assertTrue(((InterpolatedAffineModel3D) model2).getA() instanceof AffineModel3D);
+		assertTrue(((InterpolatedAffineModel3D) model2).getB() instanceof RigidModel3D);
+		assertEquals(0.3, ((InterpolatedAffineModel3D) model2).getLambda(), 0.0);
+	}
+
+	@Test
+	public void testFlattenModels3D() {
+		List<InvertibleBoundable> models = new ArrayList<>();
+		AffineModel3D model1 = new AffineModel3D();
+		model1.set(//
+				1.0, 0.0, 0.0, 0.0,//
+				0.0, 1.0, 0.0, 0.0,//
+				0.0, 0.0, 1.0, 0.0);
+		AffineModel3D model2 = new AffineModel3D();
+		model2.set(//
+				1.0, 0.0, 0.0, 2.0,//
+				0.0, 1.0, 0.0, 3.5,//
+				0.0, 0.0, 1.0, 4.7);
+		models.add(model1);
+		models.add(model2);
+
+		double[] flattened = Utils.flattenModels(models, Utils.DIM3D);
+		double[] expected = {
+				1.0, 0.0, 0.0, 0.0,//
+				0.0, 1.0, 0.0, 0.0,//
+				0.0, 0.0, 1.0, 0.0, //
+				1.0, 0.0, 0.0, 2.0,//
+				0.0, 1.0, 0.0, 3.5,//
+				0.0, 0.0, 1.0, 4.7
+		};
+		assertArrayEquals(expected, flattened, 0.0);
+	}
+
+	@Test
+	public void testFlattenModels2D() {
+		List<InvertibleBoundable> models = new ArrayList<>();
+		AffineModel2D model1 = new AffineModel2D();
+		model1.set(//
+				1.0, 0.0,//
+				0.0, 1.0,//
+				0.0, 0.0
+				);
+		AffineModel2D model2 = new AffineModel2D();
+		model2.set(//
+				-1.0, 0.0,//
+				0.0, 1.0,//
+				3.7, 4.2//
+				);
+		models.add(model1);
+		models.add(model2);
+
+		double[] flattened = Utils.flattenModels(models, Utils.DIM2D);
+		double[] expected = {
+				1.0, 0.0, 0.0, 0.0,//
+				0.0, 1.0, 0.0, 0.0,//
+				0.0, 0.0, 1.0, 0.0, //
+				-1.0, 0.0, 0.0, 3.7,//
+				0.0, 1.0, 0.0, 4.2,//
+				0.0, 0.0, 1.0, 0.0
+		};
+		assertArrayEquals(expected, flattened, 0.0);
+	}
+
+	@Test
+	public void testFlattenTranslation2D() {
+		TranslationModel2D model = new TranslationModel2D();
+		model.set(0.5, 7.6);
+		double[] flattened = Utils.flattenModels(Arrays.asList(model), Utils.DIM2D);
+		double[] expected = { //
+				1.0, 0.0, 0.0, 0.5, //
+				0.0, 1.0, 0.0, 7.6, //
+				0.0, 0.0, 1.0, 0.0 //
+		};
+		assertArrayEquals(expected, flattened, 0.0);
+	}
+}


### PR DESCRIPTION
This commit also introduces:

* a common `Utils` class, to create and manipulate various intermediates of the registration process using `Descriptor_based_registration`, and
* corresponding tests.