### PR TITLE
Create plug-ins to convert well-known text to bitmasks and vice versa

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,16 @@ If you want to install this plugin manually via the KNIME ImageJ2 integration, y
 
 | Project | Download `jar` from maven.imagej.net |
 | --- | --- |
-| [`AnalyzeSkeleton_`](https://github.com/fiji/AnalyzeSkeleton/) | [`AnalyzeSkeleton_-3.3.0.jar`](http://maven.imagej.net/service/local/repositories/releases/content/sc/fiji/AnalyzeSkeleton_/3.3.0/AnalyzeSkeleton_-3.3.0.jar) |
-| [`Descriptor_based_registration`](https://github.com/fiji/Descriptor_based_registration) | [`Descriptor_based_registration-2.1.2.jar`](http://maven.imagej.net/service/local/repositories/releases/content/sc/fiji/Descriptor_based_registration/2.1.2/Descriptor_based_registration-2.1.2.jar) |
+| [`AnalyzeSkeleton_`](https://github.com/fiji/AnalyzeSkeleton/) | [`AnalyzeSkeleton_-3.4.2.jar`](http://maven.imagej.net/service/local/repositories/releases/content/sc/fiji/AnalyzeSkeleton_/3.4.2/AnalyzeSkeleton_-3.4.2.jar) |
+| [`Descriptor_based_registration`](https://github.com/fiji/Descriptor_based_registration) | [`Descriptor_based_registration-2.1.7.jar`](http://maven.imagej.net/service/local/repositories/releases/content/sc/fiji/Descriptor_based_registration/2.1.7/Descriptor_based_registration-2.1.7.jar) |
 | [`Fiji_Plugins`](https://github.com/fiji/Fiji_Plugins) | [`Fiji_Plugins-3.1.1.jar`](http://maven.imagej.net/service/local/repositories/releases/content/sc/fiji/Fiji_Plugins/3.1.1/Fiji_Plugins-3.1.1.jar) |
 | [`fmi-trackmate-addons`](https://github.com/fmi-faim/fmi-trackmate-addons) | [`fmi-trackmate-addons-0.1.2.jar`](http://maven.imagej.net/service/local/repositories/releases/content/ch/fmi/fmi-trackmate-addons/0.1.2/fmi-trackmate-addons-0.1.2.jar) |
 | [`guava`](https://github.com/google/guava) | [`guava-21.0.jar`](http://maven.imagej.net/service/local/repositories/central/content/com/google/guava/guava/21.0/guava-21.0.jar) |
 | `jdom2` | [`jdom2-2.0.6.jar`](http://maven.imagej.net/service/local/repositories/bedatadriven/content/org/jdom/jdom2/2.0.6/jdom2-2.0.6.jar) |
-| [`jgrapht-core`](https://github.com/jgrapht/jgrapht) | [`jgrapht-core-1.3.0.jar`](http://maven.imagej.net/service/local/repositories/central/content/org/jgrapht/jgrapht-core/1.3.0/jgrapht-core-1.3.0.jar) |
+| [`jgrapht-core`](https://github.com/jgrapht/jgrapht) | [`jgrapht-core-1.4.0.jar`](http://maven.imagej.net/service/local/repositories/central/content/org/jgrapht/jgrapht-core/1.4.0/jgrapht-core-1.4.0.jar) |
+| [`jts-core`](https://github.com/locationtech/jts) | [`jts-core-1.18.1.jar`](https://repo.maven.apache.org/maven2/org/locationtech/jts/jts-core/1.18.1/jts-core-1.18.1.jar) |
 | [`legacy-imglib1`](https://github.com/fiji/legacy-imglib1) | [`legacy-imglib1-1.1.9.jar`](http://maven.imagej.net/service/local/repositories/releases/content/sc/fiji/legacy-imglib1/1.1.9/legacy-imglib1-1.1.9.jar) |
-| [`mpicbg`](https://github.com/axtimwalde/mpicbg/tree/master/mpicbg) | [`mpicbg-1.3.0.jar`](http://maven.imagej.net/service/local/repositories/releases/content/mpicbg/mpicbg/1.3.0/mpicbg-1.3.0.jar) |
-| [`SPIM_Registration`](https://github.com/fiji/SPIM_Registration) | [`SPIM_Registration-5.0.19.jar`](http://maven.imagej.net/service/local/repositories/releases/content/sc/fiji/SPIM_Registration/5.0.19/SPIM_Registration-5.0.19.jar) |
-| [`TrackMate_`](https://github.com/fiji/TrackMate) | [`TrackMate_-4.0.0.jar`](http://maven.imagej.net/service/local/repositories/releases/content/sc/fiji/TrackMate_/4.0.0/TrackMate_-4.0.0.jar) |
+| [`mpicbg`](https://github.com/axtimwalde/mpicbg/tree/master/mpicbg) | [`mpicbg-1.4.1.jar`](http://maven.imagej.net/service/local/repositories/releases/content/mpicbg/mpicbg/1.4.1/mpicbg-1.4.1.jar) |
+| [`SPIM_Registration`](https://github.com/fiji/SPIM_Registration) | [`SPIM_Registration-5.0.21.jar`](http://maven.imagej.net/service/local/repositories/releases/content/sc/fiji/SPIM_Registration/5.0.21/SPIM_Registration-5.0.21.jar) |
+| [`TrackMate_`](https://github.com/fiji/TrackMate) | [`TrackMate_-6.0.1.jar`](http://maven.imagej.net/service/local/repositories/releases/content/sc/fiji/TrackMate_/6.0.1/TrackMate_-6.0.1.jar) |
 | [`TrackMate_extras`](https://github.com/tinevez/TrackMate-extras) | [`TrackMate_extras-0.0.4.jar`](http://maven.imagej.net/service/local/repositories/releases/content/org/scijava/TrackMate_extras/0.0.4/TrackMate_extras-0.0.4.jar) |

--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,11 @@
 			<groupId>gov.nist.math</groupId>
 			<artifactId>jama</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.locationtech.jts</groupId>
+			<artifactId>jts-core</artifactId>
+			<version>1.18.1</version>
+		</dependency>
 
 		<dependency>
 			<groupId>junit</groupId>

--- a/src/main/java/ch/fmi/wkt/BitmaskToWellKnownText.java
+++ b/src/main/java/ch/fmi/wkt/BitmaskToWellKnownText.java
@@ -1,0 +1,74 @@
+/*-
+ * #%L
+ * A collection of plugins developed at the FMI Basel.
+ * %%
+ * Copyright (C) 2016 - 2021 FMI Basel
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+package ch.fmi.wkt;
+
+import net.imagej.ops.OpService;
+import net.imagej.ops.Ops;
+import net.imglib2.img.Img;
+import net.imglib2.roi.geom.real.Polygon2D;
+import net.imglib2.type.logic.BitType;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Polygon;
+import org.scijava.ItemIO;
+import org.scijava.command.Command;
+import org.scijava.command.ContextCommand;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * Plug-in to convert a 2D binary mask image to a polygon geometry serialized to
+ * well-known text (wkt)
+ * 
+ * @author Charismatic Claire
+ */
+@Plugin(type = Command.class, headless = true, menuPath = "FMI>2D Binary Mask to Well-Known Text (WKT)")
+public class BitmaskToWellKnownText extends ContextCommand {
+
+    @Parameter
+    private OpService opService;
+
+    @Parameter
+    private Img<BitType> input;
+
+    @Parameter(type = ItemIO.OUTPUT)
+    private String output;
+
+    @Override
+    public void run() {
+        // get imglib2-roi polygon from input
+        Polygon2D polygon2d = (Polygon2D) opService.run(Ops.Geometric.Contour.class, input, true);
+        // get coordinates
+        int numVertices = polygon2d.numVertices();
+        Coordinate[] coordinates = new Coordinate[numVertices + 1];
+        for (int i = 0; i < numVertices + 1; i++) {
+            Double x = polygon2d.vertex(i % numVertices).getDoublePosition(0);
+            Double y = polygon2d.vertex(i % numVertices).getDoublePosition(1);
+            coordinates[i] = new Coordinate(x, y);
+        }
+        // create GIS polygon
+        GeometryFactory factory = new GeometryFactory();
+        Polygon polygon = factory.createPolygon(coordinates);
+        // return result
+        output = polygon.toText();
+    }
+}

--- a/src/main/java/ch/fmi/wkt/WellKnownTextToBitmask.java
+++ b/src/main/java/ch/fmi/wkt/WellKnownTextToBitmask.java
@@ -94,7 +94,7 @@ public class WellKnownTextToBitmask extends ContextCommand {
             List<RealLocalizable> points = Arrays.stream(polygon.getCoordinates())
                     .map(coordinate -> new RealPoint(coordinate.getX(), coordinate.getY()))
                     .collect(Collectors.toList());
-            Polygon2D polygon2d = GeomMasks.polygon2D(points);  // imglib2-roi polygon
+            Polygon2D polygon2d = GeomMasks.closedPolygon2D(points);  // imglib2-roi polygon
             RealRandomAccessibleRealInterval<BoolType> bitmask = Masks.toRealRandomAccessibleRealInterval(polygon2d);
             // create view
             FinalInterval dims = envelopeToDims(polygon.getEnvelope());

--- a/src/main/java/ch/fmi/wkt/WellKnownTextToBitmask.java
+++ b/src/main/java/ch/fmi/wkt/WellKnownTextToBitmask.java
@@ -1,0 +1,116 @@
+/*-
+ * #%L
+ * A collection of plugins developed at the FMI Basel.
+ * %%
+ * Copyright (C) 2016 - 2021 FMI Basel
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+package ch.fmi.wkt;
+
+import net.imglib2.FinalInterval;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.RealLocalizable;
+import net.imglib2.RealPoint;
+import net.imglib2.RealRandomAccessibleRealInterval;
+import net.imglib2.converter.Converters;
+import net.imglib2.img.ImgView;
+import net.imglib2.roi.Masks;
+import net.imglib2.roi.geom.GeomMasks;
+import net.imglib2.roi.geom.real.Polygon2D;
+import net.imglib2.img.Img;
+import net.imglib2.type.logic.BitType;
+import net.imglib2.type.logic.BoolType;
+import net.imglib2.view.IntervalView;
+import net.imglib2.view.Views;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Polygon;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKTReader;
+import org.scijava.ItemIO;
+import org.scijava.command.Command;
+import org.scijava.command.ContextCommand;
+import org.scijava.log.LogService;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Plug-in to convert a polygon geometry represented in well-known text (wkt) to
+ * a 2D binary mask image
+ * 
+ * @author Charismatic Claire
+ */
+@Plugin(type = Command.class, headless = true, menuPath = "FMI>Well-Known Text (WKT) to 2D Binary Mask")
+public class WellKnownTextToBitmask extends ContextCommand {
+
+    @Parameter
+    private LogService logService;
+
+    @Parameter(label = "Well-Known Text Polygons")
+    private String text;
+
+    @Parameter(type = ItemIO.OUTPUT)
+    private Img<BitType> output;
+
+    private FinalInterval envelopeToDims(Geometry envelope) throws IllegalArgumentException {
+        Coordinate boxMin, boxMax;
+        boxMin = envelope.getCoordinates()[0];
+        if(envelope.getDimension() == 2) boxMax = envelope.getCoordinates()[2];
+        else if(envelope.getDimension() == 1) boxMax = envelope.getCoordinates()[1];
+        else throw new IllegalArgumentException(
+                String.format("Your envelop <%s> stems from another world!", envelope.toText()));
+        long[] min = new long[] { (long) boxMin.getX(), (long) boxMin.getY() };
+        long[] max = new long[] { (long) boxMax.getX(), (long) boxMax.getY() };
+        return new FinalInterval(min, max);
+    }
+
+    @Override
+    public void run() {
+        GeometryFactory factory = new GeometryFactory();
+        WKTReader reader = new WKTReader(factory);
+        try {
+            // get GIS polygon from input
+            Polygon polygon = (Polygon) reader.read(text);
+            // construct bitmask
+            List<RealLocalizable> points = Arrays.stream(polygon.getCoordinates())
+                    .map(coordinate -> new RealPoint(coordinate.getX(), coordinate.getY()))
+                    .collect(Collectors.toList());
+            Polygon2D polygon2d = GeomMasks.polygon2D(points);  // imglib2-roi polygon
+            RealRandomAccessibleRealInterval<BoolType> bitmask = Masks.toRealRandomAccessibleRealInterval(polygon2d);
+            // create view
+            FinalInterval dims = envelopeToDims(polygon.getEnvelope());
+            IntervalView<BoolType> view = Views.interval(Views.raster(bitmask), dims);
+            // create image
+            RandomAccessibleInterval<BitType> interval = Converters.convert(
+                    (RandomAccessibleInterval<BoolType>) view, (in, out) -> out.set(in.get()), new BitType());
+            Img<BitType> image = ImgView.wrap(interval);
+            // return result
+            output =  image;
+        } catch (ParseException e) {
+            logService.error(String.format("Could not create a polygon from input <%s>", text), e);
+        } catch(IllegalArgumentException e) {
+            logService.error(
+                    String.format("Could not define bounding box of polygon derived from input <%s>", text), e);
+        }
+    }
+
+}

--- a/src/test/java/ch/fmi/wkt/WellKnownTextTest.java
+++ b/src/test/java/ch/fmi/wkt/WellKnownTextTest.java
@@ -1,0 +1,57 @@
+package ch.fmi.wkt;
+
+import static org.junit.Assert.assertEquals;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.scijava.Context;
+import org.scijava.command.CommandModule;
+import org.scijava.command.CommandService;
+
+import net.imglib2.img.Img;
+import net.imglib2.type.logic.BitType;
+
+public class WellKnownTextTest {
+
+	private Context context;
+	private CommandService commandService;
+
+	@Before
+	public void setUp() throws Exception {
+		context = new Context();
+		commandService = context.service(CommandService.class);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		if (context != null) {
+			context.dispose();
+			context = null;
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testWKTRoundTrip() throws InterruptedException, ExecutionException {
+		String polygon = "POLYGON ((1 2, 2 2, 3 2, 3 3, 2 3, 1 2, 1 2))";
+
+		Map<String, Object> inputMap1 = new HashMap<>();
+		inputMap1.put("text", polygon);
+
+		CommandModule module1 = commandService.run(WellKnownTextToBitmask.class, true, inputMap1).get();
+
+		Img<BitType> img = (Img<BitType>) module1.getOutput("output");
+
+		Map<String, Object> inputMap2 = new HashMap<>();
+		inputMap2.put("input", img);
+		
+		CommandModule module2 = commandService.run(BitmaskToWellKnownText.class, true, inputMap2).get();
+
+		assertEquals(polygon, module2.getOutput("output"));
+	}
+
+}


### PR DESCRIPTION
Suppose you created a segmentation using the Image Processing environment in KNIME. You can extract all the segments from your segmentation and get a list of bitmasks. Wouldn't it be great to convert this bitmask representation of the segments to a well-known text (*.wkt) representation. Why? Because it,s more universal.

And why not go the other way round too? Suppose you have an image and a list of segments in well-known text (*.wkt) format. It should be possible to convert those to bitmasks that can be used to assemble an image segmentation using KNIME's GroupBy node.

Here is the corresponding thread in the KNIME forum: [Convert Well-Known Text (WKT) To Labeling](https://forum.knime.com/t/convert-well-known-text-wkt-to-labeling/31493)